### PR TITLE
We can't remove the hyphens here as the docker container's name is th…

### DIFF
--- a/single-module/mysql-cli.sh
+++ b/single-module/mysql-cli.sh
@@ -1,5 +1,5 @@
 #! /bin/bash -e
 
 docker run $* \
-   --name mysqlterm --link $(echo ${PWD##*/} | sed -e 's/-//g')_mysql_1:mysql --rm mysql:5.7.13 \
+   --name mysqlterm --link $(echo ${PWD##*/})_mysql_1:mysql --rm mysql:5.7.13 \
    sh -c 'exec mysql -h"$MYSQL_PORT_3306_TCP_ADDR" -P"$MYSQL_PORT_3306_TCP_PORT" -uroot -p"$MYSQL_ENV_MYSQL_ROOT_PASSWORD" -o eventuate'


### PR DESCRIPTION
…e directory name (single-module)

This fixes a single-module/build-and-test-all-mysql.sh execution which hangs on checking mysql status.

tested in evironment:
System: MacOS
docker-compose version: 1.22.0
docker version: 81.06.1-ce
