### PR TITLE
Fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ Next, launch the services using [Docker Compose](https://docs.docker.com/compose
 
 ```
 export DOCKER_HOST_IP=...
-docker-compose -f docker-compose-eventuate-mysql.yml build
-docker-compose -f docker-compose-eventuate-mysql.yml up -d
+docker-compose -f docker-compose-mysql.yml build
+docker-compose -f docker-compose-mysql.yml up -d
 ```
 
 Note:
 
-1. You can also run the Postgres version using `docker-compose-eventuate-postgres.yml`
+1. You can also run the Postgres version using `docker-compose-postgres.yml`
 2. You need to set `DOCKER_HOST_IP` before running Docker Compose.
 This must be an IP address or resolvable hostname.
 It cannot be `localhost`.


### PR DESCRIPTION
In README.md, docker-compose file name is written "docer-compose-eventuate-{dbms}.yml",
but actual it is "docker-compose-{dbms}.yml".

* before fix
```
[k@localhost]~/work/eventuate/eventuate-tram-examples-java-spring-todo-list/multi-module% docker-compose -f docker-compose-eventuate-mysql.yml build
using podman version: podman version 2.2.1
missing files:  ['docker-compose-eventuate-mysql.yml']
```
* after fix
```
[k@localhost]~/work/eventuate/eventuate-tram-examples-java-spring-todo-list/multi-module% docker-compose -f docker-compose-mysql.yml build
using podman version: podman version 2.2.1
podman build -t multi-module_todolistcommandservice -f ./todo-service/Dockerfile ./todo-service/
STEP 1: FROM java:openjdk-8u111-alpine
STEP 2: CMD java ${JAVA_OPTS} -jar todo-service.jar
...
```